### PR TITLE
Added startMinimized function

### DIFF
--- a/MSFS2020_AutoFPS/App.xaml.cs
+++ b/MSFS2020_AutoFPS/App.xaml.cs
@@ -87,7 +87,7 @@ namespace MSFS2020_AutoFPS
             timer.Start();
 
             MainWindow = new MainWindow(notifyIcon.DataContext as NotifyIconViewModel, Model);
-            if (Model.OpenWindow)
+            if (Model.OpenWindow && !Model.StartMinimized)
                 MainWindow.Show();
         }
 

--- a/MSFS2020_AutoFPS/MainWindow.xaml
+++ b/MSFS2020_AutoFPS/MainWindow.xaml
@@ -97,9 +97,10 @@
                             <RowDefinition MinHeight="32" Height="*"/>
                         </Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal" Margin="0,8,0,0" Grid.ColumnSpan="2">
-                            <Label Name="lblTargetFPS" Content="Target PC FPS" MinWidth="120"/>
-                            <TextBox x:Name="txtTargetFPS" ToolTip ="Achievable for your system" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24" MaxHeight="24" MinHeight="24" Width="42"   LostFocus="TextBox_LostFocus" KeyUp="TextBox_KeyUp"/>
-                            <CheckBox x:Name="chkOnTop" VerticalContentAlignment="Center" Width="76"  Height="24" MaxHeight="24" MinHeight="24" Click="chkOnTop_Click" Content="On top" Margin="13,0,0,0"/>
+                            <Label Name="lblTargetFPS" Content="Target PC FPS" MinWidth="75" Width="64"/>
+                            <TextBox x:Name="txtTargetFPS" ToolTip ="Achievable for your system" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="24" MaxHeight="24" MinHeight="24" Width="40"   LostFocus="TextBox_LostFocus" KeyUp="TextBox_KeyUp"/>
+                            <CheckBox x:Name="chkStartMinimized" VerticalContentAlignment="Center" Width="80"  Height="24" MaxHeight="24" MinHeight="24" Click="chkStartMinimized_Click" Content="Minimized"/>
+                            <CheckBox x:Name="chkOnTop" VerticalContentAlignment="Center" Width="65"  Height="24" MaxHeight="24" MinHeight="24" Click="chkOnTop_Click" Content="On top"/>
                             <CheckBox x:Name="chkAutoTargetFPS" VerticalContentAlignment="Center" ToolTip ="Recommended for VFR flights" Height="24" MaxHeight="24" MinHeight="24" Click="chkAutoTargetFPS_Click" Content="Auto Target FPS" IsChecked="False"/>
                         </StackPanel>
                         <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" Margin="0,8,0,0">

--- a/MSFS2020_AutoFPS/MainWindow.xaml.cs
+++ b/MSFS2020_AutoFPS/MainWindow.xaml.cs
@@ -243,6 +243,7 @@ namespace MSFS2020_AutoFPS
                 LoadSettings();
             }
             if (ServiceModel.TestVersion || serviceModel.LogSimValues) Logger.Log(LogLevel.Information, "MainWindow:LoadSettings", $"Expert: {serviceModel.UseExpertOptions} Mode: {serviceModel.ActiveGraphicsMode} ATgtFPS: {serviceModel.AutoTargetFPS} FltType: {(serviceModel.FlightTypeIFR ? "IFR" : "VFR")} TgtFPS: {txtTargetFPS.Text} TLODAMtd: {serviceModel.TLODAutoMethod[serviceModel.activeProfile]} Tol: {txtFPSTolerance.Text}" + (!serviceModel.UseExpertOptions && serviceModel.MemoryAccess == null ? "" : $" TMin: {txtMinTLod.Text} TMax: {txtMaxTLod.Text} OLODB: {serviceModel.OLODAtBase[serviceModel.activeProfile]} OLODT: {serviceModel.OLODAtTop[serviceModel.activeProfile]} OLODBAlt: {serviceModel.AltOLODBase[serviceModel.activeProfile]}") +$" TMinEx: {(!serviceModel.UseExpertOptions || serviceModel.MinTLODExtra[serviceModel.activeProfile] ? "true" : "false")} CloudQ: {serviceModel.DecCloudQ[serviceModel.activeProfile]} CRecovT: {txtCloudRecoveryTLOD.Text} Pause: {serviceModel.PauseMSFSFocusLost} TLODBAlt: {serviceModel.AltTLODBase[serviceModel.activeProfile]} MaxDesRate {serviceModel.AvgDescentRate[serviceModel.activeProfile]} CustomOLOD: {serviceModel.CustomAutoOLOD[serviceModel.activeProfile]} OLODTAlt: {serviceModel.AltOLODTop[serviceModel.activeProfile]}");
+            chkStartMinimized.IsChecked = serviceModel.StartMinimized;
         }
 
         protected void UpdateStatus()
@@ -456,6 +457,12 @@ namespace MSFS2020_AutoFPS
         private void chkOnTop_Click(object sender, RoutedEventArgs e)
         {
             serviceModel.SetSetting("OnTop", chkOnTop.IsChecked.ToString().ToLower());
+            LoadSettings();
+        }
+
+        private void chkStartMinimized_Click(object sender, RoutedEventArgs e)
+        {
+            serviceModel.SetSetting("StartMinimized", chkStartMinimized.IsChecked.ToString().ToLower());
             LoadSettings();
         }
         private void chkFlightType_Click(object sender, RoutedEventArgs e)

--- a/MSFS2020_AutoFPS/ServiceModel.cs
+++ b/MSFS2020_AutoFPS/ServiceModel.cs
@@ -105,6 +105,7 @@ namespace MSFS2020_AutoFPS
         public bool RememberWindowPos { get; set; }
 
         public bool OnTop { get; set; }
+        public bool StartMinimized { get; set; }
         public string SimBinary { get; set; }
         public string SimModule { get; set; }
         public long OffsetModuleBase { get; set; }
@@ -160,6 +161,7 @@ namespace MSFS2020_AutoFPS
             LogSimValues = Convert.ToBoolean(ConfigurationFile.GetSetting("LogSimValues", "false"));
             AutoTargetFPS = Convert.ToBoolean(ConfigurationFile.GetSetting("AutoTargetFPS", "false"));
             OnTop = Convert.ToBoolean(ConfigurationFile.GetSetting("OnTop", "false"));
+            StartMinimized = Convert.ToBoolean(ConfigurationFile.GetSetting("StartMinimized", "false"));
             PauseMSFSFocusLost = Convert.ToBoolean(ConfigurationFile.GetSetting("PauseMSFSFocusLost", "false"));
             TargetFPS_PC = Convert.ToInt32(ConfigurationFile.GetSetting("targetFpsPC", "40"));
             TargetFPS_VR = Convert.ToInt32(ConfigurationFile.GetSetting("targetFpsVR", "40"));


### PR DESCRIPTION
Added possibility to configure a minimized state initial start to remain app in background when started automatically with the flight simulator (e.g. via exe.xml).

![image](https://github.com/ResetXPDR/MSFS2020_AutoFPS/assets/7051112/aa56ff4e-3039-4c99-bfb0-72807eef37e1)
